### PR TITLE
Don't error reading WAVs whose samples end on an odd byte position

### DIFF
--- a/src/wave.cpp
+++ b/src/wave.cpp
@@ -78,8 +78,6 @@ int Wave_File::read(const std::string& filename)
 	while(pos < wavesize)
 	{
 		uint32_t chunksize, ret;
-		if(pos & 1)
-			pos++;
 
 		chunksize = *(uint32_t*)(filebuf+pos+4) + 8;
 		if(pos+chunksize > filesize)
@@ -94,6 +92,9 @@ int Wave_File::read(const std::string& filename)
 			return -1;
 		}
 		pos += chunksize;
+
+		if(pos & 1)
+			pos++;
 	}
 	free(filebuf);
 	return 0;


### PR DESCRIPTION
With the odd position check at the top, if the final byte position is odd, then the loop is re-entered again, resulting in trying to read data from past the end of the file.

This generally only occurs with 8-bit PCM data.