### PR TITLE
src/core.h: Fix FTBFS on GCC 15

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -9,6 +9,7 @@
 
 #define CTRMML_VERSION "0.3"
 
+#include <cstdint>
 #include <vector>
 #include <map>
 #include <memory>


### PR DESCRIPTION
Using `uint16_t` requires importing `cstdint`.

```
In file included from ctrmml/src/player.h:10,
                 from src/track_info.h:7,
                 from src/track_info.cpp:1:
ctrmml/src/core.h:28:18: error: 'uint16_t' was not declared in this scope
   28 | typedef std::map<uint16_t,Track> Track_Map;
      |                  ^~~~~~~~
ctrmml/src/core.h:13:1: note: 'uint16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   12 | #include <vector>
  +++ |+#include <cstdint>
   13 | #include <map>
ctrmml/src/core.h:28:32: error: template argument 1 is invalid
   28 | typedef std::map<uint16_t,Track> Track_Map;
      |                                ^
ctrmml/src/core.h:28:32: error: template argument 3 is invalid
ctrmml/src/core.h:28:32: error: template argument 4 is invalid
```