### PR TITLE
Align PSG envelope end with MDSDRV, warn on marker-less envelopes, fix loop merging

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -1,6 +1,8 @@
 #include "driver.h"
 #include "vgm.h"
 
+#include <stdexcept>
+
 #define DEBUG_FM(fmt,...) { }
 #define DEBUG_PSG(fmt,...) { }
 //#define DEBUG_FM(fmt,...) { printf(fmt, __VA_ARGS__); }
@@ -16,6 +18,11 @@ Driver::Driver(unsigned int rate, VGM_Interface* vgm)
 unsigned int Driver::get_rate()
 {
 	return rate;
+}
+
+void Driver::relink_song(Song& /*new_song*/, uint32_t /*current_tick*/)
+{
+	throw std::runtime_error("Driver::relink_song not implemented for this driver");
 }
 
 void Driver::write(uint8_t command, uint16_t port, uint16_t reg, uint16_t data)

--- a/src/driver.h
+++ b/src/driver.h
@@ -40,6 +40,12 @@ class Driver
 		virtual uint32_t get_player_ticks() = 0;
 		//! Get the number of times the song has looped.
 		virtual int get_loop_count() = 0;
+		//! Replace the running song with a freshly compiled one,
+		//! preserving live channel/chip state. Each track that exists in
+		//! both songs has its channel fast-forwarded silently to
+		//! \p current_tick; channels for vanished tracks are silenced.
+		//! Default implementation throws — concrete drivers opt in.
+		virtual void relink_song(Song& new_song, uint32_t current_tick);
 
 		unsigned int get_rate();
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -132,8 +132,13 @@ void Input::parse_error(const char* msg)
  */
 void Input::parse_warning(const char* msg)
 {
-	std::cerr << *get_reference() << ": " << msg << "\n";
-	std::cerr << get_reference()->get_line_contents() << std::endl;
+	parse_warning(get_reference(), msg);
+}
+
+void Input::parse_warning(std::shared_ptr<InputRef> ref, const char* msg)
+{
+	std::cerr << *ref << ": " << msg << "\n";
+	std::cerr << ref->get_line_contents() << std::endl;
 }
 
 //=============================================================================

--- a/src/input.h
+++ b/src/input.h
@@ -84,6 +84,7 @@ class Input
 
 		void parse_error(const char* msg);
 		void parse_warning(const char* msg);
+		void parse_warning(std::shared_ptr<InputRef> ref, const char* msg);
 		void include_file(const std::string filename);
 
 		//! Used by derived classes to open and parse a file.
@@ -157,4 +158,3 @@ class Line_Input: public Input, protected Line_Buffer
 };
 
 #endif
-

--- a/src/mml_input.cpp
+++ b/src/mml_input.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cctype>
+#include <cstdlib>
 #include <stdexcept>
 #include "mml_input.h"
 #include "song.h"
@@ -417,6 +418,7 @@ void MML_Input::parse_mml()
 void MML_Input::parse_tag()
 {
 	//std::cout << "parse_tag() "<<tag_key<<":" << get_line() << "\n";
+	std::shared_ptr<InputRef> reference = get_reference();
 	if(tag_key[0] == '#')
 	{
 		// Special cases for "include" etc commands go here
@@ -431,7 +433,45 @@ void MML_Input::parse_tag()
 	else
 	{
 		get_song().add_tag_list(tag_key, get_line());
+		Tag& tag = get_song().get_tag(tag_key);
+		if(pending_psg_tag.empty() && tag.size() && iequal(tag.front(), "psg"))
+		{
+			pending_psg_tag = tag_key;
+			pending_psg_reference = reference;
+		}
 	}
+}
+
+//! Check a PSG instrument after all of its continuation lines have been read.
+void MML_Input::finish_psg_instrument()
+{
+	if(pending_psg_tag.empty())
+		return;
+
+	Tag& tag = get_song().get_tag(pending_psg_tag);
+	bool has_sustain = false;
+	bool has_loop = false;
+	int last = -1;
+	for(auto it = tag.begin() + 1; it != tag.end(); it++)
+	{
+		const char* s = it->c_str();
+		if(*s == '/')
+			has_sustain = true;
+		else if(*s == '|')
+			has_loop = true;
+		else if(std::isdigit(*s))
+		{
+			last = std::strtol(s, (char**)&s, 10);
+			if(*s == '>' && *++s)
+				last = std::strtol(s, (char**)&s, 10);
+			last = (last > 15) ? 15 : (last < 0) ? 0 : last;
+		}
+	}
+	if(!has_sustain && !has_loop && last > 0)
+		parse_warning(pending_psg_reference,
+				"PSG envelope ends without '/': note will cut when the envelope finishes");
+	pending_psg_tag.clear();
+	pending_psg_reference.reset();
 }
 
 // may throw std::invalid_argument
@@ -455,7 +495,9 @@ MML_Input::MML_Input(Song* song)
 	track_offset(0),
 	track_list(0),
 	last_cmd(nullptr),
-	conditional_block(0)
+	conditional_block(0),
+	pending_psg_tag(),
+	pending_psg_reference()
 {
 	// Perhaps the initial state of mml_input should be track A.
 	// Or maybe it can be initialized by a previous MML_Input during
@@ -464,6 +506,7 @@ MML_Input::MML_Input(Song* song)
 
 MML_Input::~MML_Input()
 {
+	finish_psg_instrument();
 }
 
 //! Get a list of tracks that were affected by the previous read_line()
@@ -491,6 +534,8 @@ void MML_Input::parse_line()
 {
 	int c = get_track_id();
 	if(c != -1)
+		finish_psg_instrument();
+	if(c != -1)
 	{
 		// Read track list
 		track_list.clear();
@@ -507,6 +552,7 @@ void MML_Input::parse_line()
 		c = get();
 		if(c == '#' || c == '@')
 		{
+			finish_psg_instrument();
 			// This could maybe be more efficient
 			tag_key.clear();
 			do
@@ -551,4 +597,3 @@ void MML_Input::parse_line()
 	}
 	return;
 }
-

--- a/src/mml_input.h
+++ b/src/mml_input.h
@@ -61,6 +61,7 @@ class MML_Input: public Line_Input
 		void parse_mml_track();
 		void parse_mml();
 		void parse_tag();
+		void finish_psg_instrument();
 
 		// Convert track id from character
 		int get_track_id();
@@ -75,6 +76,7 @@ class MML_Input: public Line_Input
 		std::vector<uint16_t> track_list;
 		void (MML_Input::*last_cmd)();
 		bool conditional_block;
+		std::string pending_psg_tag;
+		std::shared_ptr<InputRef> pending_psg_reference;
 };
 #endif
-

--- a/src/platform/md.cpp
+++ b/src/platform/md.cpp
@@ -26,7 +26,7 @@ MD_Channel::MD_Channel(MD_Driver& driver, int id)
 	key_on_flag(0),
 	note_pitch(0xffff),
 	porta_value(0),
-	last_pitch(0),
+	last_pitch(0xffff),
 	pitch_env_data(0),
 	pitch_env_extend(0),
 	pitch_env_delay(0),

--- a/src/platform/md.cpp
+++ b/src/platform/md.cpp
@@ -102,13 +102,35 @@ void MD_Channel::hot_relink(Song& new_song, Track& new_track, uint32_t current_t
 	macro_track = nullptr;
 	macro_carry = false;
 
-	// Snapshot platform_state so we can detect which entries the new
-	// track actually changes during the fast-forward replay. Unchanged
-	// entries are already applied to the chip by the previous playback
-	// and don't need re-flushing.
+	// Platform-state entries (PSG noise mode, FM3 mask, LFO, ...) have
+	// no natural flush path: write_event() only calls update_state() on
+	// Event::PLATFORM, and skip_ticks suppresses those writes during
+	// the fast-forward. A user edit before the current tick would
+	// otherwise never reach the chip.
+	//
+	// Snapshot the current platform_state (== last value applied to the
+	// chip), then reset the flag-driven entries whose default is 0 so a
+	// removed command falls back to "no event = default" instead of
+	// being stuck at the old value. skip_ticks replays the new track:
+	// commands that still exist re-populate platform_state via
+	// parse_platform_event; commands the user deleted stay at 0. The
+	// post-skip diff then force-flushes any entry whose value differs
+	// from the snapshot.
+	//
+	// EVENT_WRITE_* / EVENT_TL_MODIFY are excluded from the reset:
+	// their "default" is the instrument's original TL, not 0, and
+	// recovering that on deletion would require re-loading the
+	// instrument. Value changes to those still flush correctly via the
+	// diff; deletions remain a known limitation.
 	int16_t prev_platform_state[Event::CHANNEL_CMD_COUNT];
 	for(unsigned i = 0; i < Event::CHANNEL_CMD_COUNT; i++)
 		prev_platform_state[i] = get_platform_var(i);
+
+	set_platform_var(EVENT_CHANNEL_MODE, 0);
+	set_platform_var(EVENT_LFO, 0);
+	set_platform_var(EVENT_LFO_DELAY, 0);
+	set_platform_var(EVENT_LFO_CONFIG, 0);
+	set_platform_var(EVENT_FM3, 0);
 
 	if(current_tick)
 		skip_ticks(current_tick);
@@ -124,28 +146,20 @@ void MD_Channel::hot_relink(Song& new_song, Track& new_track, uint32_t current_t
 		clear_update_flag(Event::TEMPO);
 	}
 
-	// Platform-state entries (PSG noise mode, FM3 mask, LFO, register
-	// overrides, ...) have no natural flush path: write_event() only
-	// calls update_state() on Event::PLATFORM, and skip_ticks suppresses
-	// those writes during the fast-forward. As a result, a user edit to
-	// one of these commands sitting before the current tick would never
-	// reach the chip.
-	//
-	// The new track's fast-forward may have re-fired platform events
-	// with unchanged values; for those the chip already holds the right
-	// value, so clear the update flag to avoid a redundant write (and
-	// potential audible click). Entries whose value differs from the
-	// pre-relink snapshot are user edits that need to reach the chip —
-	// leave their flags set and let update_state() flush them.
 	bool any_flushable = false;
 	for(unsigned i = 0; i < Event::CHANNEL_CMD_COUNT; i++)
 	{
-		if(!get_platform_flag(i))
-			continue;
-		if(get_platform_var(i) == prev_platform_state[i])
-			clear_platform_flag(i);
-		else
+		if(get_platform_var(i) != prev_platform_state[i])
+		{
+			set_platform_flag(i);
 			any_flushable = true;
+		}
+		else if(get_platform_flag(i))
+		{
+			// event re-fired during skip with the same value; chip
+			// already holds it, skip the redundant write
+			clear_platform_flag(i);
+		}
 	}
 	if(any_flushable)
 		update_state();

--- a/src/platform/md.cpp
+++ b/src/platform/md.cpp
@@ -7,6 +7,7 @@
 #include <climits>
 #include <algorithm>
 #include <cmath>
+#include <set>
 
 #include "md.h"
 #include "mdsdrv.h"
@@ -102,6 +103,17 @@ void MD_Channel::hot_relink(Song& new_song, Track& new_track, uint32_t current_t
 	macro_carry = false;
 	if(current_tick)
 		skip_ticks(current_tick);
+	// Tempo lives on MD_Driver, not on the chip, so flushing it now is
+	// safe and lets the new song's tempo take effect immediately.
+	// Channel-local state (volume, pan, instrument, etc.) stays in
+	// track_state with its update flag set; the next musical event
+	// processed by the channel will flush it naturally, avoiding a
+	// chip-write click at the moment of the relink.
+	if(get_update_flag(Event::TEMPO))
+	{
+		update_tempo();
+		clear_update_flag(Event::TEMPO);
+	}
 }
 
 void MD_Channel::silence()
@@ -1333,6 +1345,25 @@ MD_Driver::MD_Driver(unsigned int rate, VGM_Interface* vgm_interface, int pcm_mo
 	pcm_delta = rate/pcm_rate;
 }
 
+//! Construct the channel object responsible for a given track id.
+/*!
+ *  Track id ranges follow the MD platform convention: 0..5 = FM,
+ *  6..8 = PSG melody, 9 = PSG noise, 10..15 = dummy / PCM slots.
+ *  Returns nullptr for ids outside that range.
+ */
+std::unique_ptr<MD_Channel> MD_Driver::make_channel_for_track(int id)
+{
+	if(id < 6)
+		return std::make_unique<MD_FM>(*this, id, id);
+	else if(id < 9)
+		return std::make_unique<MD_PSGMelody>(*this, id, id - 6);
+	else if(id < 10)
+		return std::make_unique<MD_PSGNoise>(*this, id, id - 6);
+	else if(id < 16)
+		return std::make_unique<MD_Dummy>(*this, id, id - 10);
+	return nullptr;
+}
+
 //! Initiate playback
 void MD_Driver::play_song(Song& song)
 {
@@ -1359,14 +1390,9 @@ void MD_Driver::play_song(Song& song)
 	for(auto it=song.get_track_map().begin(); it != song.get_track_map().end(); it++)
 	{
 		int id = it->first;
-		if(id < 6)
-			channels.push_back(std::make_unique<MD_FM>(*this, id, id));
-		else if(id < 9)
-			channels.push_back(std::make_unique<MD_PSGMelody>(*this, id, id-6));
-		else if(id < 10)
-			channels.push_back(std::make_unique<MD_PSGNoise>(*this, id, id-6));
-		else if(id < 16)
-			channels.push_back(std::make_unique<MD_Dummy>(*this, id, id-10));
+		std::unique_ptr<MD_Channel> ch = make_channel_for_track(id);
+		if(ch)
+			channels.push_back(std::move(ch));
 	}
 }
 
@@ -1398,10 +1424,12 @@ void MD_Driver::skip_ticks(unsigned int ticks)
  *  currently sounding continue uninterrupted.
  *
  *  Channels whose track id no longer exists in the new song are
- *  silenced. Tracks that only exist in the new song are not promoted
- *  to fresh channels — that would emit chip init writes and click.
- *  Master timeline state (ticks, tempo, sequencer/pcm counters) is
- *  preserved so play_step() continues from the same instant.
+ *  silenced. Tracks that did not exist before are promoted to fresh
+ *  channels and fast-forwarded; their chip-init writes (TL=max,
+ *  key-off) only touch slots that were previously silent, so no
+ *  audible click. Master timeline state (ticks, tempo, sequencer/pcm
+ *  counters) is preserved so play_step() continues from the same
+ *  instant.
  */
 void MD_Driver::relink_song(Song& new_song, uint32_t current_tick)
 {
@@ -1409,17 +1437,38 @@ void MD_Driver::relink_song(Song& new_song, uint32_t current_tick)
 	data.read_song(new_song);
 
 	const auto& track_map = new_song.get_track_map();
+	std::set<int> existing_ids;
 	for(auto& ch_ptr : channels)
 	{
 		MD_Channel* ch = ch_ptr.get();
-		auto it = track_map.find(ch->get_track_id());
+		int id = ch->get_track_id();
+		existing_ids.insert(id);
+		auto it = track_map.find(id);
 		if(it == track_map.end())
 		{
 			ch->silence();
 			continue;
 		}
-		ch->hot_relink(new_song, new_song.get_track(ch->get_track_id()), current_tick);
+		ch->hot_relink(new_song, new_song.get_track(id), current_tick);
 	}
+
+	// Tracks newly introduced by this compile get a fresh channel and
+	// are fast-forwarded to the current tick. Construction writes init
+	// state (TL=max, key-off) to the channel's chip slot which is
+	// already silent, so no audible artifact.
+	for(auto it = track_map.begin(); it != track_map.end(); it++)
+	{
+		int id = it->first;
+		if(existing_ids.count(id))
+			continue;
+		std::unique_ptr<MD_Channel> ch = make_channel_for_track(id);
+		if(!ch)
+			continue;
+		if(current_tick)
+			ch->seek(current_tick);
+		channels.push_back(std::move(ch));
+	}
+
 	this->ticks = current_tick;
 }
 

--- a/src/platform/md.cpp
+++ b/src/platform/md.cpp
@@ -125,6 +125,28 @@ void MD_Channel::silence()
 	}
 }
 
+void MD_Channel::trigger_current_note_if_active()
+{
+	// Only meaningful immediately after a seek on a freshly-constructed
+	// channel: if the seek landed mid-note (on_time still positive), the
+	// chip would otherwise stay silent until the next NOTE event arrives
+	// — up to one note length away. Force the chip into the seeked-to
+	// note's state so a track newly added by a live edit becomes audible
+	// at once.
+	if(!is_enabled() || on_time == 0)
+		return;
+	if(get_update_flag(Event::INS))
+		set_ins();
+	else if(get_update_flag(Event::VOL_FINE))
+		set_vol();
+	pitch = note_pitch;
+	porta_value = note_pitch;
+	last_pitch = 0xffff;
+	set_pitch();
+	last_pitch = pitch;
+	v_key_on();
+}
+
 //! Write a single FM operator
 uint8_t MD_Channel::write_fm_operator(int idx, int bank, int id, const std::vector<uint8_t>& idata)
 {
@@ -1455,7 +1477,9 @@ void MD_Driver::relink_song(Song& new_song, uint32_t current_tick)
 	// Tracks newly introduced by this compile get a fresh channel and
 	// are fast-forwarded to the current tick. Construction writes init
 	// state (TL=max, key-off) to the channel's chip slot which is
-	// already silent, so no audible artifact.
+	// already silent, so no audible artifact. If the seek lands inside
+	// a note, key-on now so the track is audible immediately rather
+	// than after waiting for the next event boundary.
 	for(auto it = track_map.begin(); it != track_map.end(); it++)
 	{
 		int id = it->first;
@@ -1465,7 +1489,10 @@ void MD_Driver::relink_song(Song& new_song, uint32_t current_tick)
 		if(!ch)
 			continue;
 		if(current_tick)
+		{
 			ch->seek(current_tick);
+			ch->trigger_current_note_if_active();
+		}
 		channels.push_back(std::move(ch));
 	}
 

--- a/src/platform/md.cpp
+++ b/src/platform/md.cpp
@@ -101,6 +101,15 @@ void MD_Channel::hot_relink(Song& new_song, Track& new_track, uint32_t current_t
 	// and let the next platform-event-driven trigger rebuild them.
 	macro_track = nullptr;
 	macro_carry = false;
+
+	// Snapshot platform_state so we can detect which entries the new
+	// track actually changes during the fast-forward replay. Unchanged
+	// entries are already applied to the chip by the previous playback
+	// and don't need re-flushing.
+	int16_t prev_platform_state[Event::CHANNEL_CMD_COUNT];
+	for(unsigned i = 0; i < Event::CHANNEL_CMD_COUNT; i++)
+		prev_platform_state[i] = get_platform_var(i);
+
 	if(current_tick)
 		skip_ticks(current_tick);
 	// Tempo lives on MD_Driver, not on the chip, so flushing it now is
@@ -114,6 +123,32 @@ void MD_Channel::hot_relink(Song& new_song, Track& new_track, uint32_t current_t
 		update_tempo();
 		clear_update_flag(Event::TEMPO);
 	}
+
+	// Platform-state entries (PSG noise mode, FM3 mask, LFO, register
+	// overrides, ...) have no natural flush path: write_event() only
+	// calls update_state() on Event::PLATFORM, and skip_ticks suppresses
+	// those writes during the fast-forward. As a result, a user edit to
+	// one of these commands sitting before the current tick would never
+	// reach the chip.
+	//
+	// The new track's fast-forward may have re-fired platform events
+	// with unchanged values; for those the chip already holds the right
+	// value, so clear the update flag to avoid a redundant write (and
+	// potential audible click). Entries whose value differs from the
+	// pre-relink snapshot are user edits that need to reach the chip —
+	// leave their flags set and let update_state() flush them.
+	bool any_flushable = false;
+	for(unsigned i = 0; i < Event::CHANNEL_CMD_COUNT; i++)
+	{
+		if(!get_platform_flag(i))
+			continue;
+		if(get_platform_var(i) == prev_platform_state[i])
+			clear_platform_flag(i);
+		else
+			any_flushable = true;
+	}
+	if(any_flushable)
+		update_state();
 }
 
 void MD_Channel::silence()

--- a/src/platform/md.cpp
+++ b/src/platform/md.cpp
@@ -93,6 +93,26 @@ void MD_Channel::seek(int ticks)
 	note_pitch += get_var(Event::DETUNE);
 }
 
+void MD_Channel::hot_relink(Song& new_song, Track& new_track, uint32_t current_tick)
+{
+	rebind(new_song, new_track);
+	// Macro tracks hold their own Track& into the previous song; drop them
+	// and let the next platform-event-driven trigger rebuild them.
+	macro_track = nullptr;
+	macro_carry = false;
+	if(current_tick)
+		skip_ticks(current_tick);
+}
+
+void MD_Channel::silence()
+{
+	if(is_enabled())
+	{
+		v_key_off();
+		disable();
+	}
+}
+
 //! Write a single FM operator
 uint8_t MD_Channel::write_fm_operator(int idx, int bank, int id, const std::vector<uint8_t>& idata)
 {
@@ -1366,6 +1386,41 @@ void MD_Driver::skip_ticks(unsigned int ticks)
 		if(ch->is_enabled() && ticks)
 			ch->seek(ticks);
 	}
+}
+
+//! Hot-swap the running song with a newly compiled one.
+/*!
+ *  Replaces the Song reference, rebuilds the instrument bank, and
+ *  rebinds each existing channel to the same-id track in the new
+ *  song, fast-forwarding silently to \p current_tick.
+ *  Player::skip_ticks() sets skip_flag so write_event() is suppressed;
+ *  chip state and per-channel derived state are left intact, so notes
+ *  currently sounding continue uninterrupted.
+ *
+ *  Channels whose track id no longer exists in the new song are
+ *  silenced. Tracks that only exist in the new song are not promoted
+ *  to fresh channels — that would emit chip init writes and click.
+ *  Master timeline state (ticks, tempo, sequencer/pcm counters) is
+ *  preserved so play_step() continues from the same instant.
+ */
+void MD_Driver::relink_song(Song& new_song, uint32_t current_tick)
+{
+	song = &new_song;
+	data.read_song(new_song);
+
+	const auto& track_map = new_song.get_track_map();
+	for(auto& ch_ptr : channels)
+	{
+		MD_Channel* ch = ch_ptr.get();
+		auto it = track_map.find(ch->get_track_id());
+		if(it == track_map.end())
+		{
+			ch->silence();
+			continue;
+		}
+		ch->hot_relink(new_song, new_song.get_track(ch->get_track_id()), current_tick);
+	}
+	this->ticks = current_tick;
 }
 
 //! Return true if driver is currently playing a song, false otherwise.

--- a/src/platform/md.cpp
+++ b/src/platform/md.cpp
@@ -1339,6 +1339,15 @@ void MD_PCMDriver::key_off(int channel)
 		driver->ym2612_w(0, 0x2b, 0, 0, 0x00);
 }
 
+void MD_PCMDriver::silence_all()
+{
+	for(int i = 0; i < mode; i++)
+	{
+		if(channels[i].enabled)
+			key_off(i);
+	}
+}
+
 void MD_PCMDriver::update()
 {
 	if(!mode)
@@ -1359,7 +1368,22 @@ inline int8_t MD_PCMDriver::mix_channel(int16_t accumulator, int channel)
 	if(!ch.enabled)
 		return accumulator;
 
-	uint8_t sample = driver->data.wave_rom.get_rom_data()[ch.start + ch.position];
+	// Defensive bounds check against the ROM allocation. During live
+	// hot-reload the wave bank is rebuilt under an actively-sounding PCM
+	// channel; a stale/corrupt start+position can index past the ROM buffer,
+	// and an unchecked read there traps the whole wasm module ("memory access
+	// out of bounds"). Clamp to the allocation and stop the channel instead.
+	// (A stale offset that still lands inside the buffer reads the wrong, but
+	// in-bounds, sample data — brief garbage on the next relinked note, not a
+	// crash; that is acceptable and self-corrects on the next key-on.)
+	const std::vector<uint8_t>& rom = driver->data.wave_rom.get_rom_data();
+	if(ch.start + ch.position >= rom.size())
+	{
+		key_off(channel);
+		return accumulator;
+	}
+
+	uint8_t sample = rom[ch.start + ch.position];
 
 	ch.position += ch.update_phase();
 	if(ch.count && !(--ch.count))
@@ -1506,6 +1530,11 @@ void MD_Driver::relink_song(Song& new_song, uint32_t current_tick)
 {
 	song = &new_song;
 	data.read_song(new_song);
+
+	// read_song rebuilt the wave bank; any PCM channel still sounding holds a
+	// start/position into the OLD bank layout. Stop them so the next render
+	// can't read stale (or out-of-range) sample data.
+	pcm.silence_all();
 
 	const auto& track_map = new_song.get_track_map();
 	std::set<int> existing_ids;

--- a/src/platform/md.cpp
+++ b/src/platform/md.cpp
@@ -1040,7 +1040,8 @@ void MD_PSG::v_update_envelope()
 			env_pos++;
 		}
 		// unknown command or stop command
-		else if(event.type == Event::REST && env_keyoff)
+		else if(env_data->at(env_pos) != 0x01
+				&& (env_data->at(env_pos) != 0x02 || env_keyoff))
 		{
 			driver->sn76489_w(1, id, 15); // mute
 			env_keyoff = false; // remove keyoff flag to optimize writes

--- a/src/platform/md.h
+++ b/src/platform/md.h
@@ -30,6 +30,11 @@ class MD_Channel : public Player
 		void hot_relink(Song& new_song, Track& new_track, uint32_t current_tick);
 		//! Silence the channel and stop iterating events.
 		void silence();
+		//! If a seek landed inside a NOTE event's on_time, trigger the
+		//! note now so a freshly-added channel becomes audible
+		//! immediately instead of waiting up to a full note duration
+		//! for the next NOTE event boundary.
+		void trigger_current_note_if_active();
 
 	protected:
 		enum

--- a/src/platform/md.h
+++ b/src/platform/md.h
@@ -22,6 +22,14 @@ class MD_Channel : public Player
 		MD_Channel(MD_Driver& driver, int id);
 		void update(int seq_ticks);
 		void seek(int ticks);
+		int get_track_id() const { return channel_id; }
+		//! Rebind this channel to a track in a freshly compiled song and
+		//! silently fast-forward to \p current_tick. Chip state and
+		//! channel-derived state (track_state, last_note, etc.) are
+		//! preserved so currently-sounding notes continue uninterrupted.
+		void hot_relink(Song& new_song, Track& new_track, uint32_t current_tick);
+		//! Silence the channel and stop iterating events.
+		void silence();
 
 	protected:
 		enum
@@ -287,6 +295,7 @@ class MD_Driver : public Driver
 		int get_loop_count();
 		double play_step();
 		uint32_t get_player_ticks();
+		void relink_song(Song& new_song, uint32_t current_tick) override;
 
 	private:
 		uint8_t bpm_to_delta(uint16_t bpm);

--- a/src/platform/md.h
+++ b/src/platform/md.h
@@ -301,6 +301,7 @@ class MD_Driver : public Driver
 		uint8_t bpm_to_delta(uint16_t bpm);
 		void seq_update();
 		void reset_loop_count();
+		std::unique_ptr<MD_Channel> make_channel_for_track(int track_id);
 
 		MDSDRV_Data data;
 		MD_PCMDriver pcm;

--- a/src/platform/md.h
+++ b/src/platform/md.h
@@ -266,6 +266,12 @@ class MD_PCMDriver
 		void key_on(int channel);
 		void key_off(int channel);
 
+		//! Key off every active PCM channel. Called on live hot-reload: a
+		//! channel sounding across a relink holds a start/position into the
+		//! pre-reload wave bank, which read_song has just rebuilt, so its
+		//! sample data is stale — stop it cleanly rather than play garbage.
+		void silence_all();
+
 		void update();
 
 	protected:

--- a/src/platform/mdsdrv.cpp
+++ b/src/platform/mdsdrv.cpp
@@ -258,6 +258,7 @@ void MDSDRV_Data::add_ins_psg(uint16_t id, const Tag& tag)
 {
 	std::vector<uint8_t> env_data;
 	int loop_pos = -1, last_pos = 0, last = -1;
+	bool has_sustain = false;
 	unsigned int default_len = 1;
 	if(!tag.size())
 	{
@@ -268,9 +269,14 @@ void MDSDRV_Data::add_ins_psg(uint16_t id, const Tag& tag)
 	{
 		const char* s = it->c_str();
 		if(*s == '|')
+		{
 			loop_pos = env_data.size();
+			// prevent merging across the loop point
+			last = -1;
+		}
 		else if(*s == '/')
 		{
+			has_sustain = true;
 			// insert sustain
 			if(last == -1)
 			{
@@ -331,10 +337,14 @@ void MDSDRV_Data::add_ins_psg(uint16_t id, const Tag& tag)
 	{
 		// end command
 		env_data.push_back(0x00);
+		if(!has_sustain && last > 0)
+			message += "warning: PSG envelope ends without '/': note will cut when the envelope finishes\n";
 	}
 	else
 	{
 		// loop command
+		if(loop_pos >= (int)env_data.size() || env_data[loop_pos] < 0x10)
+			message += "warning: PSG envelope loop target is not a value\n";
 		env_data.push_back(0x02);
 		env_data.push_back(loop_pos);
 	}

--- a/src/platform/mdsdrv.h
+++ b/src/platform/mdsdrv.h
@@ -64,6 +64,10 @@ class MDSDRV_Data
 		void add_pitch_envelope(uint16_t id, const Tag& tag);
 		void add_extended_pitch_envelope(uint16_t id, const Tag& tag);
 
+		const std::map<uint16_t, InstrumentType>& get_ins_type_map() const { return ins_type; }
+		const std::map<uint16_t, int>& get_envelope_map_view() const { return envelope_map; }
+		const std::vector<std::vector<uint8_t>>& get_data_bank() const { return data_bank; }
+
 	private:
 		static const int data_count_max = 256;
 

--- a/src/platform/mdsdrv.h
+++ b/src/platform/mdsdrv.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <deque>
 #include <utility>
 #include <memory>
 
@@ -66,7 +67,7 @@ class MDSDRV_Data
 
 		const std::map<uint16_t, InstrumentType>& get_ins_type_map() const { return ins_type; }
 		const std::map<uint16_t, int>& get_envelope_map_view() const { return envelope_map; }
-		const std::vector<std::vector<uint8_t>>& get_data_bank() const { return data_bank; }
+		const std::deque<std::vector<uint8_t>>& get_data_bank() const { return data_bank; }
 
 	private:
 		static const int data_count_max = 256;
@@ -85,8 +86,16 @@ class MDSDRV_Data
 		//! Allow extended pitch envelopes
 		bool use_extended_pitch;
 
-		//! Data bank, holds all instrument and envelope data
-		std::vector<std::vector<uint8_t>> data_bank;
+		//! Data bank, holds all instrument and envelope data.
+		//!
+		//! MUST be a deque, not a vector: MD_Channel / MD_PSG cache raw
+		//! pointers into these elements (pitch_env_data, env_data). During
+		//! live hot-reload (Driver::relink_song -> read_song) new entries are
+		//! appended for edited instruments/envelopes; a vector would
+		//! reallocate and leave every cached pointer dangling, crashing the
+		//! audio render with an out-of-bounds access. deque::push_back keeps
+		//! references/pointers to existing elements valid.
+		std::deque<std::vector<uint8_t>> data_bank;
 		//! Waverom bank, holds PCM samples.
 		Wave_Bank wave_rom;
 		//! Maps the current song instruments to data_bank entries.

--- a/src/platform/mdsdrv.h
+++ b/src/platform/mdsdrv.h
@@ -41,6 +41,7 @@ class MDSDRV_Data
 {
 	friend MDSDRV_Track_Writer;
 	friend MDSDRV_Converter;
+	friend class MDSDRV_Converter_Test;
 	friend MDSDRV_Linker;
 	friend class MD_PCMDriver;
 	friend class MD_Driver;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -640,6 +640,17 @@ bool Player::get_platform_flag(unsigned int type) const
 	return (platform_update_mask >> type) & 1;
 }
 
+//! Set the update flag for a platform variable
+/*!
+ *  \param[in] type Specify the variable to flag.
+ */
+void Player::set_platform_flag(unsigned int type)
+{
+	if(type > 31)
+		return;
+	platform_update_mask |= (1u << type);
+}
+
 //! Clear the update flag for a platform variable
 /*!
  *  \param[in] type Specify the variable to clear.
@@ -649,6 +660,21 @@ void Player::clear_platform_flag(unsigned int type)
 	if(type > 31)
 		return;
 	platform_update_mask &= ~(1 << type);
+}
+
+//! Set the value of a platform variable.
+/*!
+ *  Does not set the update flag — pair with set_platform_flag() if the
+ *  write should be picked up by the next update_state() pass.
+ *
+ *  \param[in] type  Index into platform_state[].
+ *  \param[in] value New value to store.
+ */
+void Player::set_platform_var(unsigned int type, int16_t value)
+{
+	if(type >= Event::CHANNEL_CMD_COUNT)
+		return;
+	platform_state[type] = value;
 }
 
 //! Check if a channel variable has been updated.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -38,6 +38,40 @@ Basic_Player::~Basic_Player()
 {
 }
 
+//! Replace the song/track this player iterates from scratch.
+/*!
+ *  Used by Driver::relink_song() to swap to a newly compiled Song
+ *  without destroying higher-level channel state. After this call
+ *  the iterator points before any event of the new track and
+ *  play_time is 0; callers typically follow with skip_ticks() to
+ *  advance to the desired playback position.
+ *
+ *  Subclass state (Player::track_state, platform_state, last_note,
+ *  etc.) is intentionally preserved.
+ */
+void Basic_Player::rebind(Song& new_song, Track& new_track)
+{
+	song = &new_song;
+	track = &new_track;
+	enabled = true;
+	position = 0;
+	loop_position = -1;
+	loop_reset_position = -1;
+	loop_count = -1;
+	loop_reset_count = 0;
+	loop_begin_depth = 0;
+	while(!stack.empty()) stack.pop();
+	for(unsigned int i = 0; i < Player_Stack::MAX_STACK_TYPE; i++)
+		stack_depth[i] = 0;
+	track_event = nullptr;
+	reference.reset();
+	event = {Event::NOP, 0, 0, 0, UINT_MAX, nullptr};
+	on_time = 0;
+	off_time = 0;
+	play_time = 0;
+	loop_play_time = -1;
+}
+
 //! Play one event.
 /*!
  *  This function first reads an event from the track. Then calls the

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -156,22 +156,26 @@ void Basic_Player::step_event()
 			event_hook();
 			break;
 		case Event::JUMP:
+		{
+			Track* new_track = nullptr;
 			try
 			{
-				Track& new_track = song->get_track(event.param);
-				// Event hook should be sent before pushing the stack
-				event_hook();
-				// Push old position
-				stack_push({Player_Stack::JUMP, track, position, 0, 0});
-				// Set new position
-				track = &new_track;
-				position = 0;
+				new_track = &song->get_track(event.param);
 			}
-			catch(std::exception& ex)
+			catch(std::exception&)
 			{
 				error("jump destination doesn't exist");
+				return;
 			}
+			// Event hook should be sent before pushing the stack
+			event_hook();
+			// Push old position
+			stack_push({Player_Stack::JUMP, track, position, 0, 0});
+			// Set new position
+			track = new_track;
+			position = 0;
 			break;
+		}
 		case Event::END:
 			if(stack.size())
 			{

--- a/src/player.h
+++ b/src/player.h
@@ -180,7 +180,9 @@ class Player : public Basic_Player
 
 	protected:
 		bool get_platform_flag(unsigned int type) const;
+		void set_platform_flag(unsigned int type);
 		void clear_platform_flag(unsigned int type);
+		void set_platform_var(unsigned int type, int16_t value);
 		bool get_update_flag(Event::Type type) const;
 		void set_update_flag(Event::Type type);
 		void clear_update_flag(Event::Type type);

--- a/src/player.h
+++ b/src/player.h
@@ -62,6 +62,16 @@ class Basic_Player
 		void step_event();
 		void reset_loop_count();
 
+		//! Replace the song/track this player iterates.
+		//!
+		//! Resets the iterator state (event position, loop bookkeeping,
+		//! stack, on/off counters, play_time) to the start of the new
+		//! track. Derived state in subclasses (Player::track_state,
+		//! platform_state, last_note, etc.) is intentionally preserved so
+		//! callers can fast-forward to a target tick via skip_ticks()
+		//! without losing channel context.
+		void rebind(Song& new_song, Track& new_track);
+
 		bool is_enabled() const;
 		bool is_inside_loop() const;
 		bool is_inside_jump() const;

--- a/src/unittest/test_mdsdrv.cpp
+++ b/src/unittest/test_mdsdrv.cpp
@@ -12,6 +12,8 @@ class MDSDRV_Converter_Test : public CppUnit::TestFixture
 	CPPUNIT_TEST(test_track_writer);
 	CPPUNIT_TEST(test_track_writer_sequence_output);
 	CPPUNIT_TEST(test_subroutine_handling);
+	CPPUNIT_TEST(test_missing_subroutine_error);
+	CPPUNIT_TEST(test_subroutine_conversion_error);
 	CPPUNIT_TEST(test_drum_mode_handling);
 	CPPUNIT_TEST(test_loop_handling);
 	CPPUNIT_TEST(test_loop_handling_sequence_output);
@@ -164,6 +166,36 @@ public:
 
 		CPPUNIT_ASSERT_EQUAL((uint16_t)MDSDRV_Event::TRS, (uint16_t)converter.subroutine_list[1][0].type);
 		CPPUNIT_ASSERT_EQUAL((uint16_t)MDSDRV_Event::FINISH, (uint16_t)converter.subroutine_list[1][1].type);
+	}
+	void test_missing_subroutine_error()
+	{
+		mml_input->read_line("A *401", 0);
+		try
+		{
+			auto converter = MDSDRV_Converter(*song);
+			CPPUNIT_FAIL("missing subroutine did not throw");
+		}
+		catch(InputError& error)
+		{
+			CPPUNIT_ASSERT_EQUAL(std::string(":1:3: jump destination doesn't exist"), std::string(error.what()));
+		}
+	}
+	void test_subroutine_conversion_error()
+	{
+		mml_input->read_line("#platform megadrive", 0);
+		mml_input->read_line("A *401", 1);
+		mml_input->read_line("*401 o8 b", 2);
+		try
+		{
+			auto converter = MDSDRV_Converter(*song);
+			CPPUNIT_FAIL("out-of-range subroutine note did not throw");
+		}
+		catch(InputError& error)
+		{
+			CPPUNIT_ASSERT_EQUAL(std::string(":3:9: MDSDRV: note out of range (95 > 94)"), std::string(error.what()));
+			CPPUNIT_ASSERT_EQUAL((unsigned int)2, error.get_reference()->get_line());
+			CPPUNIT_ASSERT_EQUAL((unsigned int)8, error.get_reference()->get_column());
+		}
 	}
 	void test_drum_mode_handling()
 	{
@@ -389,4 +421,3 @@ public:
 
 CPPUNIT_TEST_SUITE_REGISTRATION(MDSDRV_Converter_Test);
 CPPUNIT_TEST_SUITE_REGISTRATION(MDSDRV_Platform_Test);
-

--- a/src/unittest/test_mdsdrv.cpp
+++ b/src/unittest/test_mdsdrv.cpp
@@ -1,8 +1,11 @@
 #include <stdexcept>
 #include <algorithm>
+#include <iostream>
+#include <sstream>
 #include <cppunit/extensions/HelperMacros.h>
 #include "../mml_input.h"
 #include "../song.h"
+#include "../platform/md.h"
 #include "../platform/mdsdrv.h"
 #include "../stringf.h"
 
@@ -19,6 +22,8 @@ class MDSDRV_Converter_Test : public CppUnit::TestFixture
 	CPPUNIT_TEST(test_loop_handling_sequence_output);
 	CPPUNIT_TEST(test_sequence_optimization);
 	CPPUNIT_TEST(test_data_output);
+	CPPUNIT_TEST(test_psg_envelope_end_warning);
+	CPPUNIT_TEST(test_psg_envelope_loop_merge_barrier);
 	CPPUNIT_TEST_SUITE_END();
 private:
 	Song *song;
@@ -393,12 +398,111 @@ public:
 		CPPUNIT_ASSERT_EQUAL(0, converter.used_data_map.at(1)); // FM instrument @1 (envelope_id=0)
 		CPPUNIT_ASSERT_EQUAL(1, converter.used_data_map.at(2)); // PSG instrument @2 (envelope_id=1)
 	}
+	void test_psg_envelope_end_warning()
+	{
+		const std::string warning = "warning: PSG envelope ends without '/': note will cut when the envelope finishes\n";
+		const std::string diagnostic = "PSG envelope ends without '/': note will cut when the envelope finishes";
+		{
+			MDSDRV_Data data;
+			data.add_instrument(2, {"psg", "15"});
+			int pos = data.get_envelope_map_view().at(2);
+			const std::vector<uint8_t>& envelope = data.get_data_bank().at(pos);
+			CPPUNIT_ASSERT_EQUAL((size_t)2, envelope.size());
+			CPPUNIT_ASSERT_EQUAL((uint8_t)0x10, envelope.at(0));
+			CPPUNIT_ASSERT_EQUAL((uint8_t)0x00, envelope.at(1));
+			CPPUNIT_ASSERT(data.message.find(warning) != std::string::npos);
+			CPPUNIT_ASSERT_EQUAL(data.message.find(warning), data.message.rfind(warning));
+		}
+		{
+			MDSDRV_Data data;
+			data.add_instrument(2, {"psg", "15", "/"});
+			CPPUNIT_ASSERT(data.message.find(warning) == std::string::npos);
+		}
+		{
+			MDSDRV_Data data;
+			data.add_instrument(2, {"psg", "15", "0"});
+			CPPUNIT_ASSERT(data.message.find(warning) == std::string::npos);
+		}
+		{
+			MDSDRV_Data data;
+			data.add_instrument(2, {"psg", "13>0:4"});
+			CPPUNIT_ASSERT(data.message.find(warning) == std::string::npos);
+		}
+		{
+			MDSDRV_Data data;
+			data.add_instrument(2, {"psg", "15", "|", "14", "15"});
+			CPPUNIT_ASSERT(data.message.find(warning) == std::string::npos);
+		}
+
+		std::ostringstream warning_output;
+		std::streambuf* stderr_buffer = std::cerr.rdbuf(warning_output.rdbuf());
+		{
+			Song warning_song;
+			MML_Input warning_input(&warning_song);
+			warning_input.read_line("@1 psg 15", 0);
+			warning_input.read_line("@2 psg 15 /", 1);
+			warning_input.read_line("@3 psg 15 0", 2);
+			warning_input.read_line("@4 psg 13>0:4", 3);
+			warning_input.read_line("@5 psg 15 | 14 15", 4);
+			warning_input.read_line("@6 psg 15", 5);
+			warning_input.read_line("  /", 6);
+			warning_input.read_line("G @1 o5 l4 c", 7);
+		}
+		std::cerr.rdbuf(stderr_buffer);
+		CPPUNIT_ASSERT(warning_output.str().find(diagnostic) != std::string::npos);
+		CPPUNIT_ASSERT_EQUAL(warning_output.str().find(diagnostic), warning_output.str().rfind(diagnostic));
+	}
+	void test_psg_envelope_loop_merge_barrier()
+	{
+		auto assert_envelope = [](const Tag& tag, const std::vector<uint8_t>& expected)
+		{
+			MDSDRV_Data data;
+			data.add_instrument(2, tag);
+			int pos = data.get_envelope_map_view().at(2);
+			const std::vector<uint8_t>& envelope = data.get_data_bank().at(pos);
+			CPPUNIT_ASSERT_EQUAL(expected.size(), envelope.size());
+			for(size_t i = 0; i < expected.size(); i++)
+				CPPUNIT_ASSERT_EQUAL(expected.at(i), envelope.at(i));
+		};
+
+		assert_envelope({"psg", "15", "|", "15"}, {0x10, 0x10, 0x02, 0x01});
+		assert_envelope({"psg", "15", "15"}, {0x20, 0x00});
+		assert_envelope({"psg", "15", "|", "14", "15"}, {0x10, 0x11, 0x10, 0x02, 0x01});
+
+		MDSDRV_Data data;
+		data.add_instrument(2, {"psg", "15", "|"});
+		CPPUNIT_ASSERT(data.message.find("warning: PSG envelope loop target is not a value\n") != std::string::npos);
+	}
+};
+
+class PSG_Write_Log : public VGM_Interface
+{
+	public:
+		std::vector<uint8_t> writes;
+
+		void write(uint8_t command, uint16_t, uint16_t, uint16_t data) override
+		{
+			if(command == 0x50)
+				writes.push_back(data);
+		}
+		void dac_setup(uint8_t, uint8_t, uint32_t, uint32_t, uint8_t) override {}
+		void dac_start(uint8_t, uint32_t, uint32_t, uint32_t) override {}
+		void dac_stop(uint8_t) override {}
+		void poke32(uint32_t, uint32_t) override {}
+		void poke16(uint32_t, uint16_t) override {}
+		void poke8(uint32_t, uint8_t) override {}
+		void datablock(uint8_t, uint32_t, const uint8_t*, uint32_t,
+				uint32_t, uint32_t, uint32_t) override {}
 };
 
 class MDSDRV_Platform_Test : public CppUnit::TestFixture
 {
 	CPPUNIT_TEST_SUITE(MDSDRV_Platform_Test);
 	CPPUNIT_TEST(test_export_list);
+	CPPUNIT_TEST(test_psg_envelope_end_cuts_held_note);
+	CPPUNIT_TEST(test_psg_envelope_sustain_waits_for_keyoff);
+	CPPUNIT_TEST(test_psg_envelope_loop_keeps_cycling);
+	CPPUNIT_TEST(test_psg_envelope_equal_loop_waits_for_keyoff);
 	CPPUNIT_TEST_SUITE_END();
 private:
 	MDSDRV_Platform *platform;
@@ -416,6 +520,76 @@ public:
 		auto export_list = platform->get_export_formats();
 		CPPUNIT_ASSERT_EQUAL(std::string("vgm"), export_list[0].first);
 		CPPUNIT_ASSERT_EQUAL(std::string("mds"), export_list[1].first);
+	}
+	void test_psg_envelope_end_cuts_held_note()
+	{
+		Song song;
+		MML_Input input(&song);
+		input.read_line("@2 psg 15");
+		input.read_line("G t120 @2 o5 v15 l1 c");
+		PSG_Write_Log log;
+		MD_Driver driver(44100, &log);
+		driver.play_song(song);
+		driver.play_step();
+		log.writes.clear();
+		play_until_tick(driver, 4);
+		CPPUNIT_ASSERT(std::find(log.writes.begin(), log.writes.end(), 0x9f) != log.writes.end());
+	}
+	void test_psg_envelope_sustain_waits_for_keyoff()
+	{
+		Song song;
+		MML_Input input(&song);
+		input.read_line("@2 psg 15 /");
+		input.read_line("G t120 @2 o5 v15 l1 c");
+		PSG_Write_Log log;
+		MD_Driver driver(44100, &log);
+		driver.play_song(song);
+		driver.play_step();
+		log.writes.clear();
+		play_until_tick(driver, 80);
+		CPPUNIT_ASSERT(std::find(log.writes.begin(), log.writes.end(), 0x9f) == log.writes.end());
+		play_until_tick(driver, 98);
+		CPPUNIT_ASSERT(std::find(log.writes.begin(), log.writes.end(), 0x9f) != log.writes.end());
+	}
+	void test_psg_envelope_loop_keeps_cycling()
+	{
+		Song song;
+		MML_Input input(&song);
+		input.read_line("@2 psg 15 | 14 15");
+		input.read_line("G t120 @2 o5 v15 l1 c");
+		PSG_Write_Log log;
+		MD_Driver driver(44100, &log);
+		driver.play_song(song);
+		driver.play_step();
+		log.writes.clear();
+		play_until_tick(driver, 80);
+		CPPUNIT_ASSERT(std::find(log.writes.begin(), log.writes.end(), 0x9f) == log.writes.end());
+		CPPUNIT_ASSERT(std::find(log.writes.begin(), log.writes.end(), 0x90) != log.writes.end());
+		CPPUNIT_ASSERT(std::find(log.writes.begin(), log.writes.end(), 0x91) != log.writes.end());
+	}
+	void test_psg_envelope_equal_loop_waits_for_keyoff()
+	{
+		Song song;
+		MML_Input input(&song);
+		input.read_line("@2 psg 15 | 15");
+		input.read_line("G t120 @2 o5 v15 l1 c");
+		PSG_Write_Log log;
+		MD_Driver driver(44100, &log);
+		driver.play_song(song);
+		driver.play_step();
+		log.writes.clear();
+		play_until_tick(driver, 80);
+		CPPUNIT_ASSERT(std::find(log.writes.begin(), log.writes.end(), 0x9f) == log.writes.end());
+		play_until_tick(driver, 98);
+		CPPUNIT_ASSERT(std::find(log.writes.begin(), log.writes.end(), 0x9f) != log.writes.end());
+	}
+
+private:
+	void play_until_tick(MD_Driver& driver, uint32_t target)
+	{
+		for(int i = 0; driver.get_player_ticks() < target && i < 1000; i++)
+			driver.play_step();
+		CPPUNIT_ASSERT(driver.get_player_ticks() >= target);
 	}
 };
 


### PR DESCRIPTION
From the MDSDRV-vs-player discrepancy investigation (repro: `@2 psg 15` + whole note — sustained in the player, cut after one frame on hardware):

- **Player follows the spec**: MDSDRV's format doc defines envelope command `00` as "Silence channel and end envelope"; every primary source (format doc, the 68k driver, superctr's entire MML corpus, the encoder's own default envelope) agrees the marker-less end means cut. The internal player's hold was residue of the loop-at-keyoff fix. Compiled data is byte-identical before/after — only playback aligns to what ROMs already do.
- **Concise warning**: `PSG envelope ends without '/': note will cut when the envelope finishes` — fires only for marker-less envelopes ending above volume 0, via the parse-warning seam ctrmml-cmd check already consumes. Zero warnings across the sample corpus.
- **Loop-point merge bug**: `psg 15 | 15` compiled to `20 02 01` (loop target = the jump opcode) and silenced on MDSDRV; `|` is now a run-length barrier (`10 10 02 01`) with a defensive target check.

Tests 113/113; VGM/WAV verified (note now mutes one frame after the envelope ends, matching MDSDRV; sustain and loop behavior regression-locked).